### PR TITLE
Add support for rendering Triple Up and Triple Down Direction (#4458)

### DIFF
--- a/lib/plugins/direction.js
+++ b/lib/plugins/direction.js
@@ -52,6 +52,7 @@ function init() {
 
   var dir2Char = {
     NONE: '⇼'
+    , TripleUp: '⤊'
     , DoubleUp: '⇈'
     , SingleUp: '↑'
     , FortyFiveUp: '↗'
@@ -59,6 +60,7 @@ function init() {
     , FortyFiveDown: '↘'
     , SingleDown: '↓'
     , DoubleDown: '⇊'
+    , TripleDown: '⤋'
     , 'NOT COMPUTABLE': '-'
     , 'RATE OUT OF RANGE': '⇕'
   };


### PR DESCRIPTION
* Support TripleUp Direction for Medtronic Guardian using a single triple arrow Unicode char